### PR TITLE
Modernize Python 2 code to get ready for Python 3

### DIFF
--- a/RFCrack.py
+++ b/RFCrack.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 
 from rflib import *
 import src.RFFunctions as tools

--- a/src/RFFunctions.py
+++ b/src/RFFunctions.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 from rflib import *
 import bitstring
 import time
@@ -23,8 +24,8 @@ def capturePayload(d, rolling_code, rf_settings):
 
         #This block is used for rolling code things
         if rolling_code and capture:           #If there is a good capture and we are attacking rollingCode execute this block
-            print "SIGNAL STRENGTH: " + str(signal_strength)
-            print "RF CAPTURE: \n" + capture +"\n"
+            print("SIGNAL STRENGTH: " + str(signal_strength))
+            print("RF CAPTURE: \n" + capture +"\n")
             decision = determineRealTransmission(signal_strength, rf_settings)
             if decision:
                 roll_captures.append(capture)  #add key with good decision to the list
@@ -38,8 +39,8 @@ def capturePayload(d, rolling_code, rf_settings):
 
         #This block is when just capturing and returning, no rolling code
         elif capture and not rolling_code:
-            print "SIGNAL STRENGTH: " + str(signal_strength)
-            print "RF CAPTURE: \n" + capture +"\n"
+            print("SIGNAL STRENGTH: " + str(signal_strength))
+            print("RF CAPTURE: \n" + capture +"\n")
 
             response = raw_input( "\"Do you want to return the above payload? (y/n)")
             if response.lower() == 'y':
@@ -77,7 +78,7 @@ def printFormatedHex(payload):
 
     formatedPayload = ""
     if (len(payload) % 2 == 0):
-        print "The following payload is currently being formated: " + payload
+        print("The following payload is currently being formated: " + payload)
         iterator = iter(payload)
         for i in iterator:
             formatedPayload += ('\\x'+i + next(iterator))
@@ -104,6 +105,6 @@ def createBytesFromPayloads(payloads):
 #------------Send Transmission--------------------#
 def sendTransmission(payload, d):
     ''' Expects formated data for sending with RFXMIT'''
-    print "Sending payload... "
+    print("Sending payload... ")
     d.RFxmit(payload,10)
-    print 'Transmission Complete'
+    print('Transmission Complete')

--- a/src/attacks.py
+++ b/src/attacks.py
@@ -1,6 +1,8 @@
+from __future__ import print_function
+from __future__ import absolute_import
 
-import RFFunctions as tools
-import findDevices, jam
+from . import RFFunctions as tools
+from . import findDevices, jam
 import time
 
 #-----------------Rolling Code-------------------------#
@@ -14,15 +16,15 @@ def rollingCode(d, rf_settings, rolling_code, jamming_variance,):
     jam.jamming(j, "start", rf_settings, rolling_code, jamming_variance)
     roll_captures, signal_strength = tools.capturePayload(d, rolling_code, rf_settings)
     print("Waiting to capture your rolling code transmission")
-    print signal_strength
-    print roll_captures
+    print(signal_strength)
+    print(roll_captures)
 
     payloads = tools.createBytesFromPayloads(roll_captures)
 
     time.sleep(1)
     jam.jamming(j, "stop", rf_settings, rolling_code, jamming_variance)
 
-    print "Sending First Payload "
+    print("Sending First Payload ")
     tools.sendTransmission(payloads[0] ,d)
     response = raw_input( "Ready to send second Payload?? (y/n) ")
     if response.lower() == "y":
@@ -32,7 +34,7 @@ def rollingCode(d, rf_settings, rolling_code, jamming_variance,):
         response = raw_input( "Choose a name to save your file as and press enter: ")
         with open("./files/"+response+".cap", 'w') as file:
             file.write(roll_captures[1])
-        print "Saved file as: ./files/"+response+".cap  You can manually replay this later with -s -u"
+        print("Saved file as: ./files/"+response+".cap  You can manually replay this later with -s -u")
 #------------------End Roll Code-------------------------#
 
 
@@ -48,7 +50,7 @@ def replayLiveCapture(d, rolling_code, rf_settings):
     if response.lower() == 'y':
         payloads = tools.createBytesFromPayloads(replay_capture)
         for payload in payloads:
-            print "WAITING TO SEND"
+            print("WAITING TO SEND")
             time.sleep(1)
             tools.sendTransmission(payload ,d)
 
@@ -57,7 +59,7 @@ def replayLiveCapture(d, rolling_code, rf_settings):
         mytime = time.strftime('%X')
         with open("./files/"+mytime+"_payload.cap", 'w') as file:
             file.write(replay_capture[0])
-        print "Saved file as: ./files/"+mytime+"_payload.cap"
+        print("Saved file as: ./files/"+mytime+"_payload.cap")
 #---------------End Replay Live Capture-------------------#
 
 
@@ -65,7 +67,7 @@ def replayLiveCapture(d, rolling_code, rf_settings):
 def replaySavedCapture(d, uploaded_payload):
     with open(uploaded_payload) as f:
         payloads = f.readlines()
-        print payloads
+        print(payloads)
         payloads = tools.createBytesFromPayloads(payloads)
 
         response = raw_input( "Send once, or forever? (o/f) Default = o ")
@@ -74,13 +76,13 @@ def replaySavedCapture(d, uploaded_payload):
             print("\nNOTE: TO STOP YOU NEED TO CTRL-Z and Unplug/Plug IN YARDSTICK-ONE\n")
             while True:
                 for payload in payloads:
-                    print "WAITING TO SEND"
+                    print("WAITING TO SEND")
                     time.sleep(1)          #You may not want this if you need rapid fire tx
                     tools.sendTransmission(payload ,d)
 
         else:
             for payload in payloads:
-                    print "WAITING TO SEND"
+                    print("WAITING TO SEND")
                     time.sleep(1)
                     tools.sendTransmission(payload ,d)
 

--- a/src/attacks.py
+++ b/src/attacks.py
@@ -5,6 +5,11 @@ from . import RFFunctions as tools
 from . import findDevices, jam
 import time
 
+try:
+    raw_input          # Python 2
+except NameError:
+    raw_input = input  # Python 3
+
 #-----------------Rolling Code-------------------------#
 def rollingCode(d, rf_settings, rolling_code, jamming_variance,):
     '''Sets up for a rolling code attack, requires a frequency

--- a/src/findDevices.py
+++ b/src/findDevices.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 from rflib import *
 import time, re, sys
 
@@ -11,7 +12,7 @@ def bruteForceFreq(d, rf_settings, interval):
     current_freq = rf_settings.frequency
 
     while not keystop():
-        print "Currently Scanning: " + str(current_freq)+ " To cancel hit enter and wait a few seconds"
+        print("Currently Scanning: " + str(current_freq)+ " To cancel hit enter and wait a few seconds")
         sniffFrequency(d)
 
         current_freq +=interval
@@ -27,8 +28,8 @@ def searchKnownFreqs(d, known_frequencies):
 
         for current_freq in known_frequencies:
             d.setFreq(current_freq)
-            print "Currently Scanning: " + str(current_freq)+" To cancel hit enter and wait a few seconds"
-            print
+            print("Currently Scanning: " + str(current_freq)+" To cancel hit enter and wait a few seconds")
+            print()
             sniffFrequency(d)
 
 
@@ -39,7 +40,7 @@ def sniffFrequency(d):
     try:
         y, z = d.RFrecv(timeout=3000)
         capture = y.encode('hex')
-        print capture
+        print(capture)
         #mytime +=1
     except ChipconUsbTimeoutException:
         pass

--- a/src/jam.py
+++ b/src/jam.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 from rflib import *
 
 
@@ -20,12 +21,12 @@ def jamming(j, action, rf_settings, rolling_code, jamming_variance=0):
     j.setFreq(frequency)
 
     if (action == "start"):
-        print "Starting Jamming on: " + str(frequency)
+        print("Starting Jamming on: " + str(frequency))
         j.setModeTX() # start transmitting
         if not rolling_code:
             raw_input("Enter to stop jamming")
-            print 'done'
+            print('done')
             j.setModeIDLE()
     if (action == "stop"):
         j.setModeIDLE() # put dongle in idle mode to stop jamming
-        print "Jamming Stopped"
+        print("Jamming Stopped")


### PR DESCRIPTION
Make the minimal, safe changes required to convert the repo's code to be syntax compatible with both Python 2 and Python 3. There may be more changes required to complete a port to Python 3 but this is a minimal, safe first step.

Run: [futurize --stage1 -w **/*.py](http://python-future.org/futurize_cheatsheet.html)

    See Stage 1: "safe" fixes http://python-future.org/automatic_conversion.html#stage-1-safe-fixes
