### PR TITLE
Set YS1 to idle on tx completion (Broken Code) 

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -5,9 +5,6 @@ sudo apt install python3-pip
 #Install BitString
 sudo pip install bitstring
 
-#Install keyboard
-sudo pip install keyboard
-
 #Install RFCat
 git clone https://github.com/atlas0fd00m/rfcat/
 sudo python setup.py install

--- a/INSTALL
+++ b/INSTALL
@@ -5,6 +5,9 @@ sudo apt install python3-pip
 #Install BitString
 sudo pip install bitstring
 
+#Install keyboard
+sudo pip install keyboard
+
 #Install RFCat
 git clone https://github.com/atlas0fd00m/rfcat/
 sudo python setup.py install

--- a/README
+++ b/README
@@ -1,4 +1,5 @@
-
+Archiving this fork. My tools fit my usage much better
+https://github.com/Crsarmv7l/DaikonTools-for-Yardstick-One
                    ___                  _        ___            _
   / __|___ _ _  ___ ___| |___   / __|_____ __ _| |__  ___ _  _ ___
  | (__/ _ \ ' \(_-</ _ \ / -_) | (__/ _ \ V  V / '_ \/ _ \ || (_-<

--- a/src/attacks.py
+++ b/src/attacks.py
@@ -53,14 +53,14 @@ def replayLiveCapture(d, rolling_code, rf_settings):
             print("WAITING TO SEND")
             time.sleep(1)
             tools.sendTransmission(payload ,d)
-
+            d.setModeIDLE()
+            
     response = input( "Save this capture for later? (y/n) ")
     if response.lower() == 'y':
         mytime = time.strftime('%b%d_%X')
         with open("./captures/"+mytime+"_payload.cap", 'w') as file:
             file.write(replay_capture[0])
         print(f"Saved file as: ./captures/{mytime}_payload.cap")
-        d.setModeIDLE()
 #---------------End Replay Live Capture-------------------#
 
 

--- a/src/attacks.py
+++ b/src/attacks.py
@@ -2,7 +2,6 @@
 from . import RFFunctions as tools
 from . import findDevices, jam, utilities
 import time, sys
-import keyboard
 sys.dont_write_bytecode = True
 #-----------------Rolling Code-------------------------#
 def rollingCode(d, rf_settings, rolling_code, jamming_variance,):
@@ -75,16 +74,13 @@ def replaySavedCapture(d, uploaded_payload):
         response = input( "Send once, or forever? (o/f) Default = o ")
 
         if response.lower() == "f":
-            print("\nNOTE: TO STOP YOU NEED TO hold ctrl+alt\n")
-            while True:
+            print("\nNOTE: TO STOP hit ENTER\n")
+            while not keystop():
                 for payload in payloads:
                     print("WAITING TO SEND")
                     time.sleep(1)          #You may not want this if you need rapid fire tx
                     tools.sendTransmission(payload ,d)
-                if keyboard.is_pressed('ctrl+alt'):
-                    print("Quitting...")
-                    d.setModeIDLE()
-                    break
+            d.setModeIDLE()
 
         else:
             for payload in payloads:

--- a/src/attacks.py
+++ b/src/attacks.py
@@ -2,6 +2,7 @@
 from . import RFFunctions as tools
 from . import findDevices, jam, utilities
 import time, sys
+import keyboard
 sys.dont_write_bytecode = True
 #-----------------Rolling Code-------------------------#
 def rollingCode(d, rf_settings, rolling_code, jamming_variance,):
@@ -29,6 +30,7 @@ def rollingCode(d, rf_settings, rolling_code, jamming_variance,):
         tools.sendTransmission(payloads[1] ,d)
 
     else:
+        d.setModeIDLE()
         response = input( "Choose a name to save your file as and press enter: ")
         with open("./captures/"+response+".cap", 'w') as file:
             file.write(roll_captures[1])
@@ -58,6 +60,7 @@ def replayLiveCapture(d, rolling_code, rf_settings):
         with open("./captures/"+mytime+"_payload.cap", 'w') as file:
             file.write(replay_capture[0])
         print(f"Saved file as: ./captures/{mytime}_payload.cap")
+        d.setModeIDLE()
 #---------------End Replay Live Capture-------------------#
 
 
@@ -72,19 +75,23 @@ def replaySavedCapture(d, uploaded_payload):
         response = input( "Send once, or forever? (o/f) Default = o ")
 
         if response.lower() == "f":
-            print("\nNOTE: TO STOP YOU NEED TO CTRL-Z and Unplug/Plug IN YARDSTICK-ONE\n")
+            print("\nNOTE: TO STOP YOU NEED TO hold ctrl+alt\n")
             while True:
                 for payload in payloads:
                     print("WAITING TO SEND")
                     time.sleep(1)          #You may not want this if you need rapid fire tx
                     tools.sendTransmission(payload ,d)
+                if keyboard.is_pressed('ctrl+alt'):
+                    print("Quitting...")
+                    d.setModeIDLE()
+                    break
 
         else:
             for payload in payloads:
                     print("WAITING TO SEND")
                     time.sleep(1)
                     tools.sendTransmission(payload ,d)
-
+                    d.setModeIDLE()
 #--------------- End Replay Saved Capture-------------------#
 
 
@@ -99,5 +106,5 @@ def deBruijn(d):
     print(f"Sending {str(len(binary))} bits length binary deBruijn payload formated to bytes")
 
     tools.sendTransmission(payload ,d)
-
+    d.setModeIDLE()
 #----------------- End DeBruijn Sequence Attack--------------------#

--- a/src/attacks.py
+++ b/src/attacks.py
@@ -76,10 +76,13 @@ def replaySavedCapture(d, uploaded_payload):
         if response.lower() == "f":
             print("\nNOTE: TO STOP hit ENTER\n")
             while not keystop():
-                for payload in payloads:
-                    print("WAITING TO SEND")
-                    time.sleep(1)          #You may not want this if you need rapid fire tx
-                    tools.sendTransmission(payload ,d)
+                try:
+                    for payload in payloads:
+                        print("WAITING TO SEND")
+                        time.sleep(1)          #You may not want this if you need rapid fire tx
+                        tools.sendTransmission(payload ,d)
+                except ChipconUsbTimeoutException:
+			            pass 	
             d.setModeIDLE()
 
         else:


### PR DESCRIPTION
Added d.setModeIDLE() after tx completion setting the YS1 back to idle. This substantially reduces and for the most part eliminates usb timeout errors. 

I also added keyboard as a requirement. It is used as a listener for the user holding ctrl+alt during continuous playback. Once heard it breaks the While True: loop after setting the YS1 back to Idle. This eliminates have to unplug/replug the YS1.

You will still get some libusb errors, or others but they can be ignored. These errors existed before my changes.